### PR TITLE
Add back API tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,7 +1033,7 @@ checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "ontodev_valve"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-scoped",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ontodev_valve"
 description = "A lightweight validation engine written in rust"
 license = "BSD-3-Clause"
-version = "0.1.11"
+version = "0.1.12"
 repository = "https://github.com/ontodev/valve.rs"
 # Because of this issue: https://github.com/lalrpop/lalrpop/issues/650 we need to use the 2018
 # edition of rust for now.

--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ pg_test: valve test/src/table.tsv | test/output
 
 api_test: valve test/src/table.tsv build/valve.db test/insert_update.sh | test/output
 	@echo "Testing API functions on sqlite and postgresql ..."
-	$< $(word 2,$^) postgresql:///valve_postgres > /dev/null
-	$< --api_test $(word 2,$^) postgresql:///valve_postgres
-	$< --api_test $(word 2,$^) $(word 3,$^)
+	./$< $(word 2,$^) postgresql:///valve_postgres > /dev/null
+	./$< --api_test $(word 2,$^) postgresql:///valve_postgres
+	./$< --api_test $(word 2,$^) $(word 3,$^)
 	$(word 4,$^) postgresql:///valve_postgres
 	$(word 4,$^) $(word 3,$^)
 	@echo "Test succeeded!"

--- a/src/api_test.rs
+++ b/src/api_test.rs
@@ -1,0 +1,134 @@
+use ontodev_valve::{
+    configure_and_or_load, get_compiled_datatype_conditions, get_compiled_rule_conditions,
+    get_parsed_structure_conditions, insert_new_row, update_row,
+    validate::{get_matching_values, validate_row},
+    valve_grammar::StartParser,
+};
+use serde_json::{json, Value as SerdeValue};
+use sqlx::{
+    any::{AnyConnectOptions, AnyKind, AnyPoolOptions},
+    query as sqlx_query,
+};
+use std::str::FromStr;
+
+pub async fn run_api_tests(table: &str, database: &str) -> Result<(), sqlx::Error> {
+    let config = configure_and_or_load(table, database, false).await?;
+    let config: SerdeValue = serde_json::from_str(config.as_str()).unwrap();
+    let config = config.as_object().unwrap();
+
+    // To connect to a postgresql database listening to a unix domain socket:
+    // ----------------------------------------------------------------------
+    // let connection_options =
+    //     AnyConnectOptions::from_str("postgres:///testdb?host=/var/run/postgresql")?;
+    //
+    // To query the connection type at runtime via the pool:
+    // -----------------------------------------------------
+    // let db_type = pool.any_kind();
+
+    let connection_options;
+    if database.starts_with("postgresql://") {
+        connection_options = AnyConnectOptions::from_str(database)?;
+    } else {
+        let connection_string;
+        if !database.starts_with("sqlite://") {
+            connection_string = format!("sqlite://{}?mode=rwc", database);
+        } else {
+            connection_string = database.to_string();
+        }
+        connection_options = AnyConnectOptions::from_str(connection_string.as_str()).unwrap();
+    }
+
+    let pool = AnyPoolOptions::new().max_connections(5).connect_with(connection_options).await?;
+    if pool.any_kind() == AnyKind::Sqlite {
+        sqlx_query("PRAGMA foreign_keys = ON").execute(&pool).await?;
+    }
+
+    let parser = StartParser::new();
+    let compiled_datatype_conditions = get_compiled_datatype_conditions(&config, &parser);
+    let parsed_structure_conditions = get_parsed_structure_conditions(&config, &parser);
+    let compiled_rule_conditions =
+        get_compiled_rule_conditions(&config, compiled_datatype_conditions.clone(), &parser);
+
+    let matching_values = get_matching_values(
+        &config,
+        &compiled_datatype_conditions,
+        &parsed_structure_conditions,
+        &pool,
+        "foobar",
+        "child",
+        None,
+    )
+    .await?;
+    assert_eq!(
+        matching_values,
+        json!([
+            {"id":"a","label":"a","order":1},
+            {"id":"b","label":"b","order":2},
+            {"id":"c","label":"c","order":3},
+            {"id":"d","label":"d","order":4},
+            {"id":"e","label":"e","order":5},
+            {"id":"f","label":"f","order":6},
+            {"id":"g","label":"g","order":7},
+            {"id":"h","label":"h","order":8}
+        ])
+    );
+
+    // NOTE: No validation of the validate/insert/update functions is done below. You must use an
+    // external script to fetch the data from the database and run a diff against a known good
+    // sample.
+    let row = json!({
+        "child": {"messages": [], "valid": true, "value": "b"},
+        "parent": {"messages": [], "valid": true, "value": "f"},
+        "xyzzy": {"messages": [], "valid": true, "value": "w"},
+        "foo": {"messages": [], "valid": true, "value": "A"},
+        "bar": {
+            "messages": [
+                {"level": "error", "message": "An unrelated error", "rule": "custom:unrelated"}
+            ],
+            "valid": false,
+            "value": "B",
+        },
+    });
+
+    let result_row = validate_row(
+        &config,
+        &compiled_datatype_conditions,
+        &compiled_rule_conditions,
+        &pool,
+        "foobar",
+        row.as_object().unwrap(),
+        true,
+        Some(1),
+    )
+    .await?;
+    update_row(&config, &pool, "foobar", &result_row, 1).await?;
+
+    let row = json!({
+        "id": {"messages": [], "valid": true, "value": "BFO:0000027"},
+        "label": {"messages": [], "valid": true, "value": "bazaar"},
+        "parent": {
+            "messages": [
+                {"level": "error", "message": "An unrelated error", "rule": "custom:unrelated"}
+            ],
+            "valid": false,
+            "value": "barrie",
+        },
+        "source": {"messages": [], "valid": true, "value": "BFOBBER"},
+        "type": {"messages": [], "valid": true, "value": "owl:Class"},
+    });
+
+    let result_row = validate_row(
+        &config,
+        &compiled_datatype_conditions,
+        &compiled_rule_conditions,
+        &pool,
+        "import",
+        row.as_object().unwrap(),
+        false,
+        None,
+    )
+    .await?;
+    let _new_row_num = insert_new_row(&config, &pool, "import", &result_row).await?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,34 @@
+mod api_test;
+
+use crate::api_test::run_api_tests;
+
 use ontodev_valve::configure_and_or_load;
 use std::{env, process};
 
 #[async_std::main]
 async fn main() -> Result<(), sqlx::Error> {
     let args: Vec<String> = env::args().collect();
-    if args.len() != 3 {
+    let table;
+    let database;
+    if args.len() == 3 {
+        table = &args[1];
+        database = &args[2];
+        configure_and_or_load(table, database, true).await?;
+    } else if args.len() == 4 && &args[1] == "--api_test" {
+        table = &args[2];
+        database = &args[3];
+        run_api_tests(table, database).await?;
+    } else {
         eprintln!(
             r#"
-Usage: valve TABLE DATABASE
+Usage: valve [--api_test] TABLE DATABASE
 Where:
   TABLE: The filename (including path) of the table table file"
   DATABASE: Can be one of:
     - A URL of the form `postgresql://...` or `sqlite://...`
-    - The filename (including path) of a sqlite database."#);
+    - The filename (including path) of a sqlite database."#
+        );
         process::exit(1);
     }
-    let table = &args[1];
-    let database = &args[2];
-    configure_and_or_load(table, database, true).await?;
     Ok(())
 }

--- a/test/expected/foobar.tsv
+++ b/test/expected/foobar.tsv
@@ -1,0 +1,10 @@
+child	parent	xyzzy	foo	bar
+b	f	w	A	B
+b	c	e		y
+c	d	f	x	y
+d	e	g	x	w
+e	f	h		
+f	g	a		
+g	h	z		
+h				
+i				

--- a/test/expected/import.tsv
+++ b/test/expected/import.tsv
@@ -1,0 +1,12 @@
+source	id	label	type	parent
+MOB	MOB:0000013	   mobecular entity	owl:Class	material entity
+ZOB	ZOB:0000013	bar	owl:Class	car
+JOB	JOB:0000013	car	owl:Class	foo
+SOB	SOB:0000013	foo	owl:Class	bar
+YOB	YOB:0000013	mar	owl:Class	jafar
+COB	BFO:0000040	material entity	owl:Class	owl:Thing
+CO B	COB:0000013	molecular dentity	owl:Class	material entity
+COB	COB:0000013	molecular entity	owl:Class	material entity
+COB	VO:0000001	vaccine	owl:Class	material entity
+BFOBBER	BFO:0000027	bazaar	owl:Class	barrie
+BOB	VO:0000001	vaccine	owl:Class	material entity

--- a/test/insert_update.sh
+++ b/test/insert_update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+if [[ $# -lt 1 ]]
+then
+    echo "Usage: $(basename $0) DATABASE"
+    exit 1
+fi
+
+db=$1
+shift
+if [[ $# -gt 0 ]]
+then
+    echo "Warning: Extra arguments: '$*' will be ignored"
+fi
+
+pwd=$(dirname $(readlink -f $0))
+export_script=$pwd/../scripts/export.py
+output_dir=$pwd/output
+expected_dir=$pwd/expected
+
+ret_value=0
+for table_path in import.tsv foobar.tsv
+do
+    table_path=${table_path#test/}
+    table_path=$pwd/output/$table_path
+    table_file=$(basename $table_path)
+    table=${table_file%.*}
+    ${export_script} data --nosort $db $output_dir $table
+    diff -q $expected_dir/${table}.tsv ${table_path}
+    ret_value=$(expr $ret_value + $?)
+done
+
+exit $ret_value


### PR DESCRIPTION
These were previously removed since they duplicate tests that are performed via [valve.py](https://github.com/ontodev/valve.py). But it is desirable to have them here as well since it isn't always convenient to test the API functions using the bindings.