### PR TITLE
Add support for real and numeric types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
 /build
+/test/output
+/test/perf_test_data/ontology
+/test/random_test_data/ontology
+/junk

--- a/test/src/column.tsv
+++ b/test/src/column.tsv
@@ -36,8 +36,10 @@ table3	related	empty	trimmed_line
 table4	foreign_column		text	unique	
 table4	other_foreign_column		text	unique	
 table4	numeric_foreign_column		integer	primary	
-table5	foo		word	primary	
-table5	bar		integer		
+table5	text		word	primary	
+table5	int		integer		
+table5	real		real		
+table5	num		numeric		
 table6	child		integer	from(table4.numeric_foreign_column)	
 table6	parent	empty	integer	tree(child)	
 table6	xyzzy	empty	integer	under(table6.child, 4)	

--- a/test/src/datatype.tsv
+++ b/test/src/datatype.tsv
@@ -10,10 +10,10 @@ integer	nonspace		match(/-?\d+/)		a positive or negative integer	INTEGER	INTEGER
 label	trimmed_line		match(/\S([^\n]*\S)*/)						
 line	text		exclude(/\n/)		a line of text				input
 nonspace	trimmed_line		exclude(/\s/)		text without whitespace				
-numeric	nonspace		match(/-?\d+(.\d+)?/)		a positive or negative number	NUMERIC	NUMERIC		
+numeric	nonspace		match(/-?\d+(\.\d+)?/)		a positive or negative number	NUMERIC	NUMERIC		
 path	line		exclude(/\n/)		a path to a file				
 prefix	word		exclude(/\W/)		a prefix for a CURIE				
-real	nonspace		match(/-?\d+(.\d+)?/)		a positive or negative real number	REAL	REAL		
+real	nonspace		match(/-?\d+(\.\d+)?/)		a positive or negative real number	REAL	REAL		
 suffix	word		exclude(/\W/)		a suffix for a CURIE				
 table_name	word		exclude(/\W/)		a table name				
 table_type	word	lowercase	in('table', 'column', 'datatype')		a table type				

--- a/test/src/datatype.tsv
+++ b/test/src/datatype.tsv
@@ -10,8 +10,10 @@ integer	nonspace		match(/-?\d+/)		a positive or negative integer	INTEGER	INTEGER
 label	trimmed_line		match(/\S([^\n]*\S)*/)						
 line	text		exclude(/\n/)		a line of text				input
 nonspace	trimmed_line		exclude(/\s/)		text without whitespace				
+numeric	nonspace		match(/-?\d+(.\d+)?/)		a positive or negative number	NUMERIC	NUMERIC		
 path	line		exclude(/\n/)		a path to a file				
 prefix	word		exclude(/\W/)		a prefix for a CURIE				
+real	nonspace		match(/-?\d+(.\d+)?/)		a positive or negative real number	REAL	REAL		
 suffix	word		exclude(/\W/)		a suffix for a CURIE				
 table_name	word		exclude(/\W/)		a table name				
 table_type	word	lowercase	in('table', 'column', 'datatype')		a table type				

--- a/test/src/ontology/table5.tsv
+++ b/test/src/ontology/table5.tsv
@@ -1,4 +1,4 @@
-foo	bar
-cat	123
-dog	-55
-rat	0
+text	int	real	num
+cat	123	0.0001	123
+dog	-55	1.2	1.2
+rat	0	-10.01	-10


### PR DESCRIPTION
This is a first pass at adding `real` and `numeric` types. I updated the `test/src/ontology/table5.tsv`.

1. SQLite `real`s are written with trailing `.0` (e.g. `0.0`, `-10.0`) but Postgres doesn't (e.g. `0`, `-10`). They agree when using `numeric`, and Postgres `real` is just 4 bytes, so maybe we don't really need `real`?
2. I'm not sure about the best Rust types to use for these. Some code I found uses Rust variable precision `Decimal` for `numeric`.
3. The perf and random tests need to be updated to cover these types.

@lmcmicu Please review what I've written and then work on these points.