### PR TITLE
Prototype for 'external' table type

### DIFF
--- a/src/valve.rs
+++ b/src/valve.rs
@@ -744,6 +744,9 @@ impl Valve {
     pub async fn dump_schema(&self) -> Result<(), ValveError> {
         let setup_statements = self.get_setup_statements().await?;
         for table in self.get_sorted_table_list(false) {
+            if !setup_statements.contains_key(table) {
+                continue;
+            }
             let table_statements = setup_statements.get(table).unwrap();
             let output = String::from(table_statements.join("\n"));
             println!("{}\n", output);


### PR DESCRIPTION
This code should not be merged, but maybe it will be helpful.

It adds support for an 'external' value in the table.type column. When a table is 'external', VALVE will not try to read it, or create it, or truncate it, or load it. The entries about external tables may still be useful for other tools that use VALVE, such as Nanobot.
